### PR TITLE
Update utils.py

### DIFF
--- a/report_generator/utils.py
+++ b/report_generator/utils.py
@@ -9,13 +9,13 @@ from datetime import date
 
 
 def handle_uploaded_file(f):
-    decoded_file = f.read().decode('utf-8').splitlines()
+    decoded_file = f.read().decode('utf-8-sig').splitlines()
     reader = csv.DictReader(decoded_file)
     data = []
     prompt = ""
     for row in reader:
         if prompt == "":
-            prompt = row['\ufeffExchange question']
+            prompt = row['Exchange question']
         data.append({
             'thought': row['Thought (original)'],
             "star": row['Star score - overall'],


### PR DESCRIPTION
decoding with 'utf-8-sig' removes the "\ufeff" from the keys. `utf-8` blindly accepts the signature, causing the first key "Exchange question" to have "\ufeff" joined at the start.


![Screenshot 2020-12-07 180858](https://user-images.githubusercontent.com/40044108/101416217-5e779d00-38b7-11eb-8c9b-fb26a28c05ea.png)

```py
f = open('exchangedata.csv', mode='r', encoding='utf-8-sig')
reader = csv.DictReader(f)
print(next(reader).keys())
f.close()
f = open('exchangedata.csv', mode='r', encoding='utf-8')
reader = csv.DictReader(f)
print(next(reader).keys())
f.close()```
